### PR TITLE
update Rust for 2017-12-17 nightly.

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -55,7 +55,7 @@ pub fn fn_body(cx: &mut ExtCtxt, fn_info: &HotswapFnInfo) -> P<Block> {
         };
 
         func($input_idents)
-    }).unwrap())
+    }).into_inner())
 }
 
 pub fn macro_expansion(cx: &mut ExtCtxt, hotswap_fns: &[HotswapFnInfo]) -> P<Expr> {
@@ -205,7 +205,7 @@ pub fn macro_expansion(cx: &mut ExtCtxt, hotswap_fns: &[HotswapFnInfo]) -> P<Exp
                 }
             }
         });
-    }).unwrap();
+    }).into_inner();
 
     P(block)
 }


### PR DESCRIPTION
Hi.
Fix to build on the newely nightly.

Version)
E:\work\Rust\hotswap-test>rustup show
Default host: x86_64-pc-windows-msvc

installed toolchains
--------------------

stable-x86_64-pc-windows-gnu
stable-x86_64-pc-windows-msvc
nightly-x86_64-pc-windows-gnu (default)
nightly-x86_64-pc-windows-msvc

active toolchain
----------------

nightly-x86_64-pc-windows-gnu (default)
rustc 1.26.0-nightly (bedbad611 2018-02-26)