### PR TITLE
abi now lives under rustc-target, not syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![feature(quote, plugin_registrar, rustc_private, box_syntax, stmt_expr_attributes)]
 
 extern crate rustc_plugin;
+extern crate rustc_target;
 extern crate syntax;
 
 use rustc_plugin::registry::Registry;
 
-use syntax::abi::Abi;
+use rustc_target::spec::abi::Abi;
 use syntax::ast::{Attribute, Ident, Item, ItemKind, MetaItem, Mod, Name, Ty, VisibilityKind};
 use syntax::attr;
 use syntax::codemap::Span;


### PR DESCRIPTION
I ran into this attempting to build rust-hotswap with the latest nightly, was very confused.

```
rustc 1.27.0-nightly (91db9dcf3 2018-05-04)
```